### PR TITLE
fix: check for undefined and null

### DIFF
--- a/storyblok-vue.js
+++ b/storyblok-vue.js
@@ -12,7 +12,7 @@
 
     Vue.directive('editable', {
       bind: function(el, binding) {
-        if (typeof binding.value._editable === 'undefined') {
+        if (typeof binding.value._editable === 'undefined' || binding.value._editable === null) {
           return
         }
 


### PR DESCRIPTION
The GraphQL API returns `null` in `_editable` if content-version is set to "published", therefore the check fails.