### PR TITLE
Modify v-editable directive to react to data changes

### DIFF
--- a/storyblok-vue.js
+++ b/storyblok-vue.js
@@ -10,19 +10,21 @@
 
   function install(Vue) {
 
-    Vue.directive('editable', {
-      bind: function(el, binding) {
-        if (typeof binding.value._editable === 'undefined' || binding.value._editable === null) {
-          return
-        }
-
-        var options = JSON.parse(binding.value._editable.replace('<!--#storyblok#', '').replace('-->', ''))
-
-        el.setAttribute('data-blok-c', JSON.stringify(options))
-        el.setAttribute('data-blok-uid', options.id + '-' + options.uid)
-
-        addClass(el, 'storyblok__outline')
+    Vue.directive('editable', function(el, binding) {
+      if (
+        typeof binding.value._editable === 'undefined' ||
+        binding.value._editable === null || 
+        (binding.oldValue && binding.oldValue._editable === binding.value._editable)
+      ) {
+        return
       }
+
+      var options = JSON.parse(binding.value._editable.replace('<!--#storyblok#', '').replace('-->', ''))
+
+      el.setAttribute('data-blok-c', JSON.stringify(options))
+      el.setAttribute('data-blok-uid', options.id + '-' + options.uid)
+
+      addClass(el, 'storyblok__outline')
     })
 
     if (typeof window !== 'undefined' && typeof window.storyblok !== 'undefined') {


### PR DESCRIPTION
This fixes an issue that I encountered using nuxt full-static preview mode where my site loads the baked "published" storyblok json without the _editable fields on first open. When the nuxt preview mode re-fetches the live "draft" data, the `v-editable` directive has already run the bind function and does not set the required data attributes. This makes the `v-editable` directive react to changes in the _editable data and will only run when the data has changed.