### PR TITLE
Add check for undefined binding value

### DIFF
--- a/storyblok-vue.js
+++ b/storyblok-vue.js
@@ -12,7 +12,7 @@
 
     Vue.directive('editable', {
       bind: function(el, binding) {
-        if (typeof binding.value._editable === 'undefined' || binding.value._editable === null) {
+        if (!binding.value || typeof binding.value._editable === 'undefined' || binding.value._editable === null) {
           return
         }
 


### PR DESCRIPTION
In some instances, the value passed to `v-editable` can be null or undefined, meaning a check for the type of `binding.value._editable` can throw an error. This PR adds a simple check to cater to that scenario.