### PR TITLE
fix: check we're in the story to load the bridge

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -56,7 +56,10 @@ export const useStoryblok = async (
   const story: Ref<ISbStoryData> = ref(null);
 
   onMounted(() => {
-    if (story.value && story.value.id) {
+    const storyId = new URL(window.location.href).searchParams.get(
+      "_storyblok"
+    );
+    if (story.value && story.value.id && story.value.id == +storyId) {
       useStoryblokBridge(
         story.value.id,
         (evStory) => (story.value = evStory),

--- a/playground/pages/useStoryblokTwice.vue
+++ b/playground/pages/useStoryblokTwice.vue
@@ -1,0 +1,11 @@
+<script setup>
+import { useStoryblok } from "@storyblok/vue";
+
+const story = await useStoryblok("vue", { version: "draft" });
+const storyTest = await useStoryblok("vue/test", { version: "draft" });
+</script>
+
+<template>
+  <StoryblokComponent v-if="story" :blok="story.content" />
+  <StoryblokComponent v-if="storyTest" :blok="storyTest.content" />
+</template>


### PR DESCRIPTION
This PR is an open discussion to see if loading the correct bridge per StoryId in our composable could be a nice workaround for people loading multiple stories on one page.

Discord thread: https://discord.com/channels/700316478792138842/700324774722928700/1073205959108857866
Reference issue -> https://github.com/storyblok/storyblok-nuxt/issues/251

Workaround for the old plugin from Vue 2 to consider -> https://github.com/cyberbobs/storyblok-nuxt/commit/3b2601c91ad8d34e1e1f425d3a87ac7a8555f2c9
