### PR TITLE
fix(SDK-38): Simplify ResolveRelations and ResolveLinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ app.component("Teaser", Teaser);
 
 The simplest way is by using the `useStoryblok` one-liner composable. Where you need to pass as first parameter the `slug`, while the second and third parameters, `apiOptions` and `bridgeOptions` respectively, are optional:
 
+> `resolveRelations` and `resolveLinks` from `bridgeOptions` can be excluded if you're already defining them as `resolve_relations` and `resolve_links` in `apiOptions`, we will add them by default. But you will always be able to overwrite them.
+
 ```html
 <script setup>
   import { useStoryblok } from "@storyblok/vue";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -55,6 +55,12 @@ export const useStoryblok = async (
 ) => {
   const story: Ref<ISbStoryData> = ref(null);
 
+  bridgeOptions.resolveRelations =
+    bridgeOptions.resolveRelations ?? apiOptions.resolve_relations;
+
+  bridgeOptions.resolveLinks =
+    bridgeOptions.resolveLinks ?? apiOptions.resolve_links;
+
   onMounted(() => {
     if (story.value && story.value.id) {
       useStoryblokBridge(

--- a/playground/pages/HomeShort.vue
+++ b/playground/pages/HomeShort.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { useStoryblok } from "@storyblok/vue";
-const story = await useStoryblok("vue", { version: "draft" });
+const story = await useStoryblok(
+  "vue",
+  { version: "draft", resolve_relations: ["Article.author"] }
+  // { resolveRelations: "Article.categories" }
+);
 </script>
 
 <template>


### PR DESCRIPTION
- Include API options `resolve_relations` and `resolve_links` as default state of the `bridgeOptions`.
- Add a hint in docs and a check in the playground.