### PR TITLE
fix: enhance reactivity in StoryblokRichText by watching both doc and resolvers with deep true

### DIFF
--- a/src/components/StoryblokRichText.vue
+++ b/src/components/StoryblokRichText.vue
@@ -12,13 +12,14 @@ const props = defineProps<StoryblokRichTextProps>();
 const renderedDoc = ref();
 const root = () => renderedDoc.value;
 
-watch(props.doc, (doc) => {
+watch([() => props.doc, () => props.resolvers], ([doc, resolvers]) => {
   const { render } = useStoryblokRichText({
-    resolvers: (props.resolvers as StoryblokRichTextResolvers<VNode>) ?? {},
+    resolvers: (resolvers as StoryblokRichTextResolvers<VNode>) ?? {},
   });
   renderedDoc.value = render(doc as StoryblokRichTextNode<VNode>);
 }, {
   immediate: true,
+  deep: true,
 });
 </script>
 


### PR DESCRIPTION
This PR solves the invalid watch source undefined issue with props of StoryblokRichtext

Closes #768